### PR TITLE
Add note about syncing scripts and notebooks when contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,12 @@ python Wangview.py <PATH_TO_OUTPUT_DIRECTORY>
 ```shell
 python Wangview.py ../Wangscape/build/bin/example3/output/
 ```
+## Contributing
+
+The repository structure may change in the future, but for now the Python scripts and IPython notebooks should be kept in sync.
+Pull requests should make synchronous changes to both scripts and notebooks.
+
+If you prefer to work on notebooks, they can be converted to scripts using using [nbconvert](https://nbconvert.readthedocs.io).
+This can be done automatically using save hooks ([1](http://jupyter-notebook.readthedocs.io/en/latest/extending/savehooks.html), [2](http://stackoverflow.com/questions/29329667/ipython-notebook-script-deprecated-how-to-replace-with-post-save-hook)), or (deprecated) running IPython/Jupyter with the `--script` flag.
+
+If you prefer to work on the scripts, the edited scripts can be converted back to notebooks using a tool like [PY2NB](https://github.com/sklam/py2nb).


### PR DESCRIPTION
Until #9 is resolved, it's important to keep the tracked files in sync. This PR makes a note of that in `README.md`.